### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(EXTENSION_CATEGORY "Examples")
 set(EXTENSION_CONTRIBUTORS "Leonard Nürnberg (AIM, Mass General Brigham)")
 set(EXTENSION_DESCRIPTION "MHub Runner is a 3D Slicer plugin that seamlessly integrates Deep Learning models from the Medical Hub repository (MHub) into 3D Slicer.")
 set(EXTENSION_ICONURL "https://mhub.ai/slicer/SlicerMHubRunner.png")
-set(EXTENSION_SCREENSHOTURLS "https://mhub.ai/slicer/image01.png")
+set(EXTENSION_SCREENSHOTURLS "https://mhub.ai/slicer/image01.png https://mhub.ai/slicer/image02.png https://mhub.ai/slicer/image03.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.