### PR TITLE
COMP: Fix extension packaging updating project name to match extension name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 
-project(SlicerMRunner)
+project(MHubRunner)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information


### PR DESCRIPTION
This commit is expected to fix the following error:

```
  error: EXTENSION_FILE CMake variable points to a inexistent file or
  directory: /.../MHubRunner-build/./SlicerMRunner.json
Call Stack (most recent call first):
  /work/Preview/Slicer-0/Extensions/CMake/SlicerExtensionPackageAndUploadTarget.cmake:206 (slicerFunctionExtractExtensionDescriptionFromJson)
```